### PR TITLE
making fwd slightly faster

### DIFF
--- a/cpp/wav_cuda.cu
+++ b/cpp/wav_cuda.cu
@@ -7,9 +7,7 @@
 #define INDEX3D(a, b, c, db, dc) (((a) * (db) * (dc) + (b) * (dc) + (c)))
 
 #define COEFF 0.867325070f
-
 #define MAX_DIM 2048
-
 #define ALL_THREADS_IN_WARP 0xFFFFFFFF
 
 __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
@@ -19,19 +17,14 @@ __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
                            torch::PackedTensorAccessor64<float, 3> result,
                            int batch_size, int batch_size_padded, int in_feats, int out_feats, int numThreads)
 {
-
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int in_warp_idx = threadIdx.x % warpSize;
-
-    // x.size(): (batch_size, in_feats)
 
     int ibatch = idx % batch_size_padded;
     int iin = (idx / batch_size_padded) % in_feats;
     int iout = idx / (batch_size_padded * in_feats);
 
     float s, b, w;
-    // must ensure a warp has same iout and iin
-    // <=> a batch is a multiple of 32
     if (in_warp_idx == 0)
     {
         s = scale[iout][iin];
@@ -47,9 +40,12 @@ __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
 
     if (ibatch < batch_size)
     {
+        float x_val;
+        if (in_warp_idx == 0) {
+            x_val = x[ibatch][iin];
+        }
 
-        /* optimization: should not access memory one time for each thread */
-        float x_val = x[ibatch][iin];
+        x_val = __shfl_sync(ALL_THREADS_IN_WARP, x_val, 0);
 
         float y2 = s * s * (x_val + b) * (x_val + b);
         float u = COEFF * w * (y2 - 1) * expf(-0.5f * y2);
@@ -57,6 +53,7 @@ __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
         result[iout][iin][ibatch] = u;
     }
 }
+
 
 __global__ void bwd_kernel(const torch::PackedTensorAccessor64<float, 2> gout,
                            const torch::PackedTensorAccessor64<float, 2> x,
@@ -100,6 +97,10 @@ __global__ void bwd_kernel(const torch::PackedTensorAccessor64<float, 2> gout,
         grad_w_expand[ibatch][iout][iin] = gout_val * g_w;
     }
 }
+
+
+
+
 
 void fwd_launcher(const torch::PackedTensorAccessor64<float, 2> x,
                   const torch::PackedTensorAccessor64<float, 2> scale,

--- a/cpp/wav_cuda.cu
+++ b/cpp/wav_cuda.cu
@@ -25,6 +25,8 @@ __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
     int iout = idx / (batch_size_padded * in_feats);
 
     float s, b, w;
+    // must ensure a warp has same iout and iin
+    // <=> a batch is a multiple of 32
     if (in_warp_idx == 0)
     {
         s = scale[iout][iin];
@@ -53,7 +55,6 @@ __global__ void fwd_kernel(const torch::PackedTensorAccessor64<float, 2> x,
         result[iout][iin][ibatch] = u;
     }
 }
-
 
 __global__ void bwd_kernel(const torch::PackedTensorAccessor64<float, 2> gout,
                            const torch::PackedTensorAccessor64<float, 2> x,
@@ -97,10 +98,6 @@ __global__ void bwd_kernel(const torch::PackedTensorAccessor64<float, 2> gout,
         grad_w_expand[ibatch][iout][iin] = gout_val * g_w;
     }
 }
-
-
-
-
 
 void fwd_launcher(const torch::PackedTensorAccessor64<float, 2> x,
                   const torch::PackedTensorAccessor64<float, 2> scale,


### PR DESCRIPTION
I tried to make the backward faster too, but failed for now. I think you did a great job : ). However, I got to squeeze ≈6ms on the 'forward' on my RTX 4090 compared to the current implementation.  
![image](https://github.com/Da1sypetals/cuda-Wavelet-KAN/assets/140188098/fc21f78e-e45d-423d-9c30-8b0292e1d69c)
